### PR TITLE
CC3XX: Apply changes to feature-cc-psa-crypto-drivers 

### DIFF
--- a/include/psa/crypto_driver_contexts_composites.h
+++ b/include/psa/crypto_driver_contexts_composites.h
@@ -38,6 +38,9 @@
 
 /* Include the context structure definitions for those drivers that were
  * declared during the autogeneration process. */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+#include "cc3xx_crypto_primitives.h"
+#endif
 
 /* Include the context structure definitions for the Mbed TLS software drivers */
 #include "psa/crypto_builtin_composites.h"
@@ -55,6 +58,9 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_TEST)
     mbedtls_transparent_test_driver_mac_operation_t transparent_test_driver_ctx;
     mbedtls_opaque_test_driver_mac_operation_t opaque_test_driver_ctx;
+#endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+    cc3xx_mac_operation_t cc3xx_driver_ctx;
 #endif
 } psa_driver_mac_context_t;
 

--- a/include/psa/crypto_driver_contexts_primitives.h
+++ b/include/psa/crypto_driver_contexts_primitives.h
@@ -37,6 +37,10 @@
 
 /* Include the context structure definitions for those drivers that were
  * declared during the autogeneration process. */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+/* Change the path to fit your machine */
+#include "cc3xx_crypto_primitives.h"
+#endif
 
 /* Include the context structure definitions for the Mbed TLS software drivers */
 #include "psa/crypto_builtin_primitives.h"
@@ -53,6 +57,9 @@ typedef union {
     mbedtls_psa_hash_operation_t mbedtls_ctx;
 #if defined(PSA_CRYPTO_DRIVER_TEST)
     mbedtls_transparent_test_driver_hash_operation_t test_driver_ctx;
+#endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+    cc3xx_hash_operation_t cc3xx_driver_ctx;
 #endif
 } psa_driver_hash_context_t;
 

--- a/include/psa/crypto_driver_contexts_primitives.h
+++ b/include/psa/crypto_driver_contexts_primitives.h
@@ -38,9 +38,8 @@
 /* Include the context structure definitions for those drivers that were
  * declared during the autogeneration process. */
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-/* Change the path to fit your machine */
 #include "cc3xx_crypto_primitives.h"
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
 /* Include the context structure definitions for the Mbed TLS software drivers */
 #include "psa/crypto_builtin_primitives.h"
@@ -69,6 +68,9 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_TEST)
     mbedtls_transparent_test_driver_cipher_operation_t transparent_test_driver_ctx;
     mbedtls_opaque_test_driver_cipher_operation_t opaque_test_driver_ctx;
+#endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+    cc3xx_cipher_operation_t cc3xx_driver_ctx;
 #endif
 } psa_driver_cipher_context_t;
 

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -1323,6 +1323,7 @@ psa_status_t psa_driver_wrapper_hash_compute(
     if (status != PSA_ERROR_NOT_SUPPORTED)
         return status;
 #endif
+
     /* If software fallback is compiled in, try fallback */
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
     status = mbedtls_psa_hash_compute( alg, input, input_length,
@@ -1642,6 +1643,14 @@ psa_status_t psa_driver_wrapper_mac_compute(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_mac_compute(attributes, key_buffer, key_buffer_size, alg,
+                input, input_length,
+                mac, mac_size, mac_length);
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1710,6 +1719,17 @@ psa_status_t psa_driver_wrapper_mac_sign_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_mac_sign_setup(
+                    &operation->ctx.cc3xx_driver_ctx,
+                    attributes,
+                    key_buffer, key_buffer_size,
+                    alg);
+            if (status == PSA_SUCCESS)
+                operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
+            if (status != PSA_ERROR_NOT_SUPPORTED)
+                return status;
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1781,6 +1801,17 @@ psa_status_t psa_driver_wrapper_mac_verify_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_mac_verify_setup(
+                &operation->ctx.cc3xx_driver_ctx,
+                attributes,
+                key_buffer, key_buffer_size,
+                alg);
+            if (status == PSA_SUCCESS)
+                operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
+            if (status != PSA_ERROR_NOT_SUPPORTED)
+                return status;
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1847,6 +1878,10 @@ psa_status_t psa_driver_wrapper_mac_update(
                         &operation->ctx.opaque_test_driver_ctx,
                         input, input_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return(cc3xx_mac_update(&operation->ctx.cc3xx_driver_ctx, input, input_length));
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) input;
@@ -1881,6 +1916,11 @@ psa_status_t psa_driver_wrapper_mac_sign_finish(
                         &operation->ctx.opaque_test_driver_ctx,
                         mac, mac_size, mac_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return(cc3xx_mac_sign_finish(&operation->ctx.cc3xx_driver_ctx,
+                        mac, mac_size, mac_length));
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) mac;
@@ -1915,6 +1955,12 @@ psa_status_t psa_driver_wrapper_mac_verify_finish(
                         &operation->ctx.opaque_test_driver_ctx,
                         mac, mac_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return(cc3xx_mac_verify_finish(
+                        &operation->ctx.cc3xx_driver_ctx,
+                        mac, mac_length));
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) mac;
@@ -1942,6 +1988,10 @@ psa_status_t psa_driver_wrapper_mac_abort(
             return( mbedtls_test_opaque_mac_abort(
                         &operation->ctx.opaque_test_driver_ctx ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return(cc3xx_mac_abort(&operation->ctx.cc3xx_driver_ctx));
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             return( PSA_ERROR_INVALID_ARGUMENT );

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -45,6 +45,18 @@
 #endif /* PSA_CRYPTO_DRIVER_TEST */
 
 /* Repeat above block for each JSON-declared driver during autogeneration */
+
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+#ifndef PSA_CRYPTO_DRIVER_PRESENT
+#define PSA_CRYPTO_DRIVER_PRESENT
+#endif
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+/* Change the path to fit your machine */
+#include "cc3xx.h"
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
+
 #endif /* MBEDTLS_PSA_CRYPTO_DRIVERS */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -56,6 +68,17 @@
 #define PSA_CRYPTO_TRANSPARENT_TEST_DRIVER_ID (2)
 #define PSA_CRYPTO_OPAQUE_TEST_DRIVER_ID (3)
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+
+
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+#ifndef PSA_CRYPTO_DRIVER_PRESENT
+#define PSA_CRYPTO_DRIVER_PRESENT
+#endif
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#define PSA_CRYPTO_DRIVER_CC3XX_ID (4)
+#endif
 
 /* Support the 'old' SE interface when asked to */
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
@@ -1219,7 +1242,12 @@ psa_status_t psa_driver_wrapper_hash_compute(
     if( status != PSA_ERROR_NOT_SUPPORTED )
         return( status );
 #endif
-
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+    status = cc3xx_hash_compute(alg, input, input_length, hash, hash_size,
+            hash_length);
+    if (status != PSA_ERROR_NOT_SUPPORTED)
+        return status;
+#endif
     /* If software fallback is compiled in, try fallback */
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
     status = mbedtls_psa_hash_compute( alg, input, input_length,
@@ -1253,6 +1281,16 @@ psa_status_t psa_driver_wrapper_hash_setup(
 
     if( status != PSA_ERROR_NOT_SUPPORTED )
         return( status );
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+    status = cc3xx_hash_setup(&operation->ctx.cc3xx_driver_ctx, alg);
+    if( status == PSA_SUCCESS )
+        operation->id = PSA_CRYPTO_DRIVER_CC3XX_ID;
+
+    if( status != PSA_ERROR_NOT_SUPPORTED) {
+        return( status );
+    }
 #endif
 
     /* If software fallback is compiled in, try fallback */
@@ -1290,6 +1328,13 @@ psa_status_t psa_driver_wrapper_hash_clone(
                         &source_operation->ctx.test_driver_ctx,
                         &target_operation->ctx.test_driver_ctx ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+            target_operation->id = PSA_CRYPTO_DRIVER_CC3XX_ID;
+            return( cc3xx_hash_clone(
+                        &source_operation->ctx.cc3xx_driver_ctx,
+                        &target_operation->ctx.cc3xx_driver_ctx ) );
+#endif
         default:
             (void) target_operation;
             return( PSA_ERROR_BAD_STATE );
@@ -1312,6 +1357,12 @@ psa_status_t psa_driver_wrapper_hash_update(
         case PSA_CRYPTO_TRANSPARENT_TEST_DRIVER_ID:
             return( mbedtls_test_transparent_hash_update(
                         &operation->ctx.test_driver_ctx,
+                        input, input_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+            return( cc3xx_hash_update(
+                        &operation->ctx.cc3xx_driver_ctx,
                         input, input_length ) );
 #endif
         default:
@@ -1340,6 +1391,12 @@ psa_status_t psa_driver_wrapper_hash_finish(
                         &operation->ctx.test_driver_ctx,
                         hash, hash_size, hash_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+            return( cc3xx_hash_finish(
+                        &operation->ctx.cc3xx_driver_ctx,
+                        hash, hash_size, hash_length ) );
+#endif
         default:
             (void) hash;
             (void) hash_size;
@@ -1361,6 +1418,11 @@ psa_status_t psa_driver_wrapper_hash_abort(
         case PSA_CRYPTO_TRANSPARENT_TEST_DRIVER_ID:
             return( mbedtls_test_transparent_hash_abort(
                         &operation->ctx.test_driver_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+            return( cc3xx_hash_abort(
+                        &operation->ctx.cc3xx_driver_ctx ) );
 #endif
         default:
             return( PSA_ERROR_BAD_STATE );

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -44,8 +44,6 @@
 #include "test/drivers/test_driver.h"
 #endif /* PSA_CRYPTO_DRIVER_TEST */
 
-/* Repeat above block for each JSON-declared driver during autogeneration */
-
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
 #ifndef PSA_CRYPTO_DRIVER_PRESENT
 #define PSA_CRYPTO_DRIVER_PRESENT
@@ -53,10 +51,10 @@
 #ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
 #define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
 #endif
-/* Change the path to fit your machine */
 #include "cc3xx.h"
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
+/* Repeat above block for each JSON-declared driver during autogeneration */
 #endif /* MBEDTLS_PSA_CRYPTO_DRIVERS */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -69,16 +67,9 @@
 #define PSA_CRYPTO_OPAQUE_TEST_DRIVER_ID (3)
 #endif /* PSA_CRYPTO_DRIVER_TEST */
 
-
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-#ifndef PSA_CRYPTO_DRIVER_PRESENT
-#define PSA_CRYPTO_DRIVER_PRESENT
-#endif
-#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
-#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
-#endif
-#define PSA_CRYPTO_DRIVER_CC3XX_ID (4)
-#endif
+#define PSA_CRYPTO_CC3XX_DRIVER_ID (4)
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
 /* Support the 'old' SE interface when asked to */
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
@@ -794,6 +785,20 @@ psa_status_t psa_driver_wrapper_cipher_encrypt(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_psa_cipher_encrypt( attributes,
+                                               key_buffer,
+                                               key_buffer_size,
+                                               alg,
+                                               input,
+                                               input_length,
+                                               output,
+                                               output_size,
+                                               output_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -876,6 +881,20 @@ psa_status_t psa_driver_wrapper_cipher_decrypt(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_psa_cipher_decrypt( attributes,
+                                               key_buffer,
+                                               key_buffer_size,
+                                               alg,
+                                               input,
+                                               input_length,
+                                               output,
+                                               output_size,
+                                               output_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -953,6 +972,20 @@ psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_cipher_encrypt_setup(
+                &operation->ctx.cc3xx_driver_ctx,
+                attributes,
+                key_buffer,
+                key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1025,6 +1058,20 @@ psa_status_t psa_driver_wrapper_cipher_decrypt_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+            status = cc3xx_cipher_decrypt_setup(
+                &operation->ctx.cc3xx_driver_ctx,
+                attributes,
+                key_buffer,
+                key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1092,6 +1139,12 @@ psa_status_t psa_driver_wrapper_cipher_set_iv(
                         &operation->ctx.opaque_test_driver_ctx,
                         iv, iv_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return( cc3xx_cipher_set_iv(
+                        &operation->ctx.cc3xx_driver_ctx,
+                        iv, iv_length ) );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1135,6 +1188,13 @@ psa_status_t psa_driver_wrapper_cipher_update(
                         input, input_length,
                         output, output_size, output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return( cc3xx_cipher_update(
+                        &operation->ctx.cc3xx_driver_ctx,
+                        input, input_length,
+                        output, output_size, output_length ) );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1175,6 +1235,12 @@ psa_status_t psa_driver_wrapper_cipher_finish(
                         &operation->ctx.opaque_test_driver_ctx,
                         output, output_size, output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            return( cc3xx_cipher_finish(
+                        &operation->ctx.cc3xx_driver_ctx,
+                        output, output_size, output_length ) );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX*/
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1215,6 +1281,15 @@ psa_status_t psa_driver_wrapper_cipher_abort(
                 sizeof( operation->ctx.opaque_test_driver_ctx ) );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_CC3XX)
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            status = cc3xx_cipher_abort(
+                         &operation->ctx.cc3xx_driver_ctx );
+            mbedtls_platform_zeroize(
+                &operation->ctx.cc3xx_driver_ctx,
+                sizeof( operation->ctx.cc3xx_driver_ctx ) );
+            return( status );
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1286,12 +1361,12 @@ psa_status_t psa_driver_wrapper_hash_setup(
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     status = cc3xx_hash_setup(&operation->ctx.cc3xx_driver_ctx, alg);
     if( status == PSA_SUCCESS )
-        operation->id = PSA_CRYPTO_DRIVER_CC3XX_ID;
+        operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
 
     if( status != PSA_ERROR_NOT_SUPPORTED) {
         return( status );
     }
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
     /* If software fallback is compiled in, try fallback */
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1329,12 +1404,12 @@ psa_status_t psa_driver_wrapper_hash_clone(
                         &target_operation->ctx.test_driver_ctx ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-        case PSA_CRYPTO_DRIVER_CC3XX_ID:
-            target_operation->id = PSA_CRYPTO_DRIVER_CC3XX_ID;
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            target_operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
             return( cc3xx_hash_clone(
                         &source_operation->ctx.cc3xx_driver_ctx,
                         &target_operation->ctx.cc3xx_driver_ctx ) );
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
         default:
             (void) target_operation;
             return( PSA_ERROR_BAD_STATE );
@@ -1360,11 +1435,11 @@ psa_status_t psa_driver_wrapper_hash_update(
                         input, input_length ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
             return( cc3xx_hash_update(
                         &operation->ctx.cc3xx_driver_ctx,
                         input, input_length ) );
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
         default:
             (void) input;
             (void) input_length;
@@ -1392,11 +1467,11 @@ psa_status_t psa_driver_wrapper_hash_finish(
                         hash, hash_size, hash_length ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
             return( cc3xx_hash_finish(
                         &operation->ctx.cc3xx_driver_ctx,
                         hash, hash_size, hash_length ) );
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
         default:
             (void) hash;
             (void) hash_size;
@@ -1420,10 +1495,10 @@ psa_status_t psa_driver_wrapper_hash_abort(
                         &operation->ctx.test_driver_ctx ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
-        case PSA_CRYPTO_DRIVER_CC3XX_ID:
+        case PSA_CRYPTO_CC3XX_DRIVER_ID:
             return( cc3xx_hash_abort(
                         &operation->ctx.cc3xx_driver_ctx ) );
-#endif
+#endif /* PSA_CRYPTO_DRIVER_CC3XX */
         default:
             return( PSA_ERROR_BAD_STATE );
     }


### PR DESCRIPTION
The [`feature-cc-psa-crypto-drivers`](https://github.com/noonfom/mbedtls/tree/feature-cc-psa-crypto-drivers) branch is based on [`development`](https://github.com/noonfom/mbedtls/tree/development) (mbedtls-3.0). This PR applies the `CC3XX` commits from the old, mbedtls-2.0-based [branch](https://github.com/noonfom/mbedtls/tree/dev_2.x-feature-cc-psa-crypto-driver) to the tip of this new branch, cleaning the history a little.  